### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ fcli --help
 
 ## Nornir-based inventory mode
 
-In this mode, a Nornir configuration file must be provided with the `-c` option. The Nornir inventory is polulated by the `InventoryPlugin` and associated options as specified in the config file. See below for an example with the included `YAMLInventory` plugin and the associated inventory files. This mode is typically used for real hardware-based fabric.
+In this mode, a Nornir configuration file must be provided with the `-c` option. The Nornir inventory is populated by the `InventoryPlugin` and associated options as specified in the config file. See below for an example with the included `YAMLInventory` plugin and the associated inventory files. This mode is typically used for real hardware-based fabric.
 
-Create the Nornir confguration file, for example:
+Create the Nornir configuration file, for example:
 
 ```yaml
 # nornir_config.yaml


### PR DESCRIPTION
## Summary
- correct typos in README around inventory instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aebf8165c832c9141ee8323a60f92