### PR TITLE
Add subscribe wrapper for gNMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,3 +399,17 @@ Show all EVPN RT=2 routes for MAC address that starts with "1A:DC":
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
+
+### subscribe
+
+The connection object exposes a thin wrapper around `pygnmi.client.gNMIclient.subscribe`. The following example subscribes to interface updates for 30 seconds:
+
+```python
+from nornir_srl.connections.srlinux import SrLinux
+
+device = SrLinux()
+device.open(hostname="10.0.0.1", username="admin", password="admin", port=57400, extras={"insecure": True})
+for msg in device.subscribe(paths=["/interface"], mode="stream", timeout=30):
+    print(msg)
+device.close()
+```

--- a/nornir_srl/connections/srlinux.py
+++ b/nornir_srl/connections/srlinux.py
@@ -177,3 +177,33 @@ class SrLinux(
                 diff += "\n"
 
         return diff
+
+    def subscribe(
+        self,
+        paths: List[str],
+        mode: str = "stream",
+        timeout: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Wrapper around :pymeth:`gNMIclient.subscribe`.
+
+        Parameters
+        ----------
+        paths:
+            List of gNMI paths to subscribe to.
+        mode:
+            Subscription mode (``"stream"``, ``"once"`` or ``"poll"``).
+        timeout:
+            Optional timeout for the subscription in seconds.
+        kwargs:
+            Additional keyword arguments forwarded to :class:`gNMIclient`.
+        """
+
+        if not getattr(self, "_connection", None):
+            raise Exception("no active connection")
+
+        params: Dict[str, Any] = {"path": paths, "mode": mode}
+        if timeout is not None:
+            params["timeout"] = timeout
+        params.update(kwargs)
+        return self._connection.subscribe(**params)

--- a/tests/test_nornir_srl.py
+++ b/tests/test_nornir_srl.py
@@ -1,5 +1,59 @@
+import sys
+import types
+
+dummy_pg = types.ModuleType("pygnmi")
+dummy_client = types.ModuleType("pygnmi.client")
+class Dummy(object):
+    pass
+dummy_client.gNMIclient = Dummy
+dummy_pg.client = dummy_client
+sys.modules.setdefault("pygnmi", dummy_pg)
+sys.modules.setdefault("pygnmi.client", dummy_client)
+
+dummy_nornir_cfg = types.ModuleType("nornir.core.configuration")
+class DummyConfig:
+    pass
+dummy_nornir_cfg.Config = DummyConfig
+sys.modules.setdefault("nornir.core.configuration", dummy_nornir_cfg)
+
+dummy_nornir_exc = types.ModuleType("nornir.core.exceptions")
+class DummyExc(Exception):
+    pass
+dummy_nornir_exc.ConnectionException = DummyExc
+sys.modules.setdefault("nornir.core.exceptions", dummy_nornir_exc)
+
+dummy_jmes = types.ModuleType("jmespath")
+def _noop(*args, **kwargs):
+    return {}
+dummy_jmes.search = _noop
+sys.modules.setdefault("jmespath", dummy_jmes)
+
 from nornir_srl import __version__
+from nornir_srl.connections.srlinux import SrLinux
 
 
 def test_version():
     assert __version__ == '0.2.22'
+
+
+class DummyConn:
+    def __init__(self):
+        self.called = False
+        self.kw = {}
+
+    def subscribe(self, **kwargs):
+        self.called = True
+        self.kw = kwargs
+        return "ok"
+
+
+def test_subscribe_wrapper():
+    dev = SrLinux()
+    dev._connection = DummyConn()
+    result = dev.subscribe(paths=["/system/name"], mode="once", timeout=1)
+    assert result == "ok"
+    assert dev._connection.called is True
+    assert dev._connection.kw["path"] == ["/system/name"]
+    assert dev._connection.kw["mode"] == "once"
+    assert dev._connection.kw["timeout"] == 1
+


### PR DESCRIPTION
## Summary
- extend `SrLinux` with subscribe wrapper around PyGNMI
- document subscribe usage in README
- test subscribe method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aecac8ed0832c83ee8a6ea3d11d2a