### PR TITLE
Switch BGP RIB query to streaming gNMI

### DIFF
--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -253,7 +253,7 @@ class RoutingMixin:
 
         attribs: Dict[str, Dict[str, Any]] = dict()
 
-        resp = self.get(paths=[PATH_BGP_PATH_ATTRIBS], datatype="state")
+        resp = self.stream_get(paths=[PATH_BGP_PATH_ATTRIBS], mode="once")
         for ni in resp[0].get("network-instance", []):
             if ni["name"] not in attribs:
                 attribs[ni["name"]] = dict()
@@ -262,8 +262,9 @@ class RoutingMixin:
                 attribs[ni["name"]].update({path_copy.pop("index"): path_copy})
 
         path_spec: Dict[str, str] = PATH_SPECS[route_fam]
-        resp = self.get(
-            paths=[str(path_spec.get("path"))], datatype=path_spec["datatype"]
+        resp = self.stream_get(
+            paths=[str(path_spec.get("path"))],
+            mode="once",
         )
         for ni in resp[0].get("network-instance", []):
             ni = augment_routes(ni, attribs[ni["name"]])

--- a/nornir_srl/connections/srlinux.py
+++ b/nornir_srl/connections/srlinux.py
@@ -141,12 +141,10 @@ class SrLinux(
         if not self._connection:
             raise Exception("no active connection")
 
-        subs = [{"path": p} for p in paths]
+        subs = {"subscription": [{"path": p} for p in paths], "mode": mode, "encoding": "json_ietf"}
         responses: List[Dict[str, Any]] = []
         for msg in self._connection.subscribe(
             subscribe=subs,
-            mode=mode,
-            encoding="json_ietf",
             timeout=timeout,
         ):
             responses.extend(normalize_gnmi_resp(msg))


### PR DESCRIPTION
## Summary
- add `stream_get` helper wrapping gNMI subscribe
- use `stream_get` in routing `get_bgp_rib`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad9fd74fc832ca4202ff82d425535