### PR TITLE
Add tunnel-table report, BGP path attributes, ifstats counters, JSON cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,15 @@ Options:
   --help                 Show this message and exit.
 
 Commands:
-  bgp-peers  Displays BGP Peers and their status
-  bgp-rib    Displays BGP RIB
-  ipv4-rib   Displays IPv4 RIB entries, LPM lookup
-  lldp       Displays LLDP Neighbors
-  mac        Displays MAC Table
-  ni         Displays Network Instances and interfaces
-  subif      Displays Sub-Interfaces of nodes
-  sys-info   Displays System Info of nodes
+  bgp-peers     Displays BGP Peers and their status
+  bgp-rib       Displays BGP RIB
+  ipv4-rib      Displays IPv4 RIB entries, LPM lookup
+  lldp          Displays LLDP Neighbors
+  mac           Displays MAC Table
+  ni            Displays Network Instances and interfaces
+  subif         Displays Sub-Interfaces of nodes
+  sys-info      Displays System Info of nodes
+  tunnel-table  Displays the IP tunnel-table (LDP, SR-ISIS, VXLAN, ...)
 ```
 
 # Installation
@@ -212,14 +213,15 @@ Options:
   --help                 Show this message and exit.
 
 Commands:
-  bgp-peers  Displays BGP Peers and their status
-  bgp-rib    Displays BGP RIB
-  ipv4-rib   Displays IPv4 RIB entries, LPM lookup
-  lldp       Displays LLDP Neighbors
-  mac        Displays MAC Table
-  ni         Displays Network Instances and interfaces
-  subif      Displays Sub-Interfaces of nodes
-  sys-info   Displays System Info of nodes
+  bgp-peers     Displays BGP Peers and their status
+  bgp-rib       Displays BGP RIB
+  ipv4-rib      Displays IPv4 RIB entries, LPM lookup
+  lldp          Displays LLDP Neighbors
+  mac           Displays MAC Table
+  ni            Displays Network Instances and interfaces
+  subif         Displays Sub-Interfaces of nodes
+  sys-info      Displays System Info of nodes
+  tunnel-table  Displays the IP tunnel-table (LDP, SR-ISIS, VXLAN, ...)
 ```
 
 To run a specific report, use the corresponding command, e.g. `fcli mac` to display the MAC table of all nodes in the inventory. The output is a table with columns relevant to the report.
@@ -400,6 +402,38 @@ Show all EVPN RT=2 routes for MAC address that starts with "1A:DC":
 | clab-4l2s-s2 | default | *>   | 01:24:24:24:24:24:24:00:00:01 | 0.0.0.0     | 1A:DC:0E:FF:00:41 | 192.168.255.2:202 | i       | 192.168.255.2 | igp    | 192.168.255.2   | 202 |
 | clab-4l2s-s2 | default | *>   | 01:24:24:24:24:24:24:00:00:01 | 10.200.1.10 | 1A:DC:0E:FF:00:41 | 192.168.255.2:202 | i       | 192.168.255.2 | igp    | 192.168.255.2   | 202 |
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+```
+
+#### bgp-rib path attributes
+
+The `bgp-rib` table shows a curated set of priority fields so it stays readable.
+Non-table output (`-o json`, `-o yaml`, `-o csv`) and the MCP tool automatically
+include the full set of path attributes for each route: standard `communities`,
+Site-of-Origin (`soo`), BGP domain-path (`dpath`), `tunnel-encap` extended-community,
+route-target (`RT`), `as-path`, route status (`valid`/`best`/`used`), `tie-break`
+reason and `internal-tags`. Use `--detail`/`-d` to also include these columns in the
+table output.
+
+```
+fcli -o json bgp-rib -r evpn -t 5            # full attributes (json)
+fcli -d bgp-rib -r evpn -t 5                 # full attributes in the table too
+```
+
+### tunnel-table
+
+Show the IP tunnel-table with the resolved egress interface, next-hop and pushed
+MPLS label-stack. Useful to verify which transport (LDP, SR-ISIS, RSVP, VXLAN, ...)
+a remote endpoint is reached over, and on which port.
+
+`fcli tunnel-table -f type=ldp`
+
+```
+                                     Tunnel Table
++-----------------------------------------------------------------------------------------+
+| Node  | NI      | Prefix          | type | owner   | pref | metric | next-hop     | egress-itf        | label   |
+|-------+---------+-----------------+------+---------+------+--------+--------------+-------------------+---------|
+| dcgw1 | default | 192.0.2.152/32  | ldp  | ldp_mgr | 9    | 10     | ['10.255.0.1'] | ['ethernet-1/5.0'] | ['20000'] |
++-----------------------------------------------------------------------------------------+
 ```
 
 # MCP Server for AI Agents

--- a/nornir_srl/cli.py
+++ b/nornir_srl/cli.py
@@ -22,6 +22,7 @@ from nornir.core.task import Result, Task, AggregatedResult
 from nornir.core.inventory import Host
 
 from .connections.srlinux import CONNECTION_NAME
+from .connections.helpers import clean_structured_key
 from .utils.logging_config import setup_logging
 from . import __version__
 
@@ -188,6 +189,9 @@ def print_structured(
     if not rows:
         typer.echo("No data...")
         return
+
+    col_names = [clean_structured_key(c) for c in col_names]
+    rows = [{clean_structured_key(k): v for k, v in row.items()} for row in rows]
 
     all_cols = ["Node"] + col_names
 
@@ -702,6 +706,20 @@ def static_routes(
 
 
 @app.command()
+def tunnel_table(
+    ctx: typer.Context,
+    field_filter: Optional[List[str]] = typer.Option(None, "--field-filter", "-f"),
+) -> None:
+    """Displays the IP tunnel-table (LDP, SR-ISIS, RSVP, VXLAN, ...)"""
+
+    def _tunnel(task: Task) -> Result:
+        device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+        return Result(host=task.host, result=device.get_tunnel_table())
+
+    run_show(ctx, "tunnel_table", _tunnel, field_filter, title="Tunnel Table")
+
+
+@app.command()
 def bgp_rib(
     ctx: typer.Context,
     route_fam: str = typer.Option(
@@ -710,13 +728,22 @@ def bgp_rib(
     route_type: Optional[str] = typer.Option(
         None, "--route-type", "-t", help="Route type for EVPN"
     ),
+    detail: bool = typer.Option(
+        False,
+        "--detail",
+        "-d",
+        help="Include all path attributes (communities, SoO, D-PATH, tunnel-encap, "
+        "status). Automatically enabled for non-table output (json/yaml/csv).",
+    ),
     field_filter: Optional[List[str]] = typer.Option(None, "--field-filter", "-f"),
 ) -> None:
     """Displays BGP RIB"""
 
+    want_detail = detail or ctx.obj["output"] != OutputFormat.TABLE
+
     def _bgp_rib(task: Task) -> Result:
         device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
-        kwargs = {"route_fam": route_fam}
+        kwargs: Dict[str, Any] = {"route_fam": route_fam, "detail": want_detail}
         if route_type is not None:
             kwargs["route_type"] = route_type
         return Result(host=task.host, result=device.get_bgp_rib(**kwargs))

--- a/nornir_srl/connections/helpers.py
+++ b/nornir_srl/connections/helpers.py
@@ -94,6 +94,25 @@ def diff_obj(a: Dict, a_name: str, b: Dict, b_name: str) -> Tuple[bool, str]:
         return (False, "")
 
 
+_ORDER_PREFIX_RE = re.compile(r"^\d+_")
+
+
+def clean_structured_key(key: Any) -> Any:
+    """Normalize a column/field name for structured (JSON/YAML/CSV) output.
+
+    Table reports prefix some field names with ``<n>_`` (e.g. ``0_st``,
+    ``1_peer``) purely to control column ordering, and embed newlines in
+    multi-line headers (e.g. ``"AF: EVPN\\nRx/Act/Tx"``). Neither is relevant
+    for machine-readable output, so strip the ordering prefix and collapse
+    whitespace/newlines for non-table formats.
+    """
+    if not isinstance(key, str):
+        return key
+    cleaned = _ORDER_PREFIX_RE.sub("", key)
+    cleaned = re.sub(r"\s+", " ", cleaned.replace("\n", " ")).strip()
+    return cleaned
+
+
 def filter_fields(d: Dict, *fields: str) -> Dict:
     return {k: v for k, v in d.items() if k in [f.replace("_", "-") for f in fields]}
 

--- a/nornir_srl/connections/ifstats.py
+++ b/nornir_srl/connections/ifstats.py
@@ -38,13 +38,15 @@ class InterfaceStatsMixin:
 
         dt = t2 - t1
 
-        # Build lookup: interface-name -> {in-octets, out-octets} for each sample
+        # Build lookup: interface-name -> counters for each sample
         def _parse(resp: List[Dict[str, Any]]) -> Dict[str, Dict[str, int]]:
             result: Dict[str, Dict[str, int]] = {}
             for itf in resp[0].get("interface", []):
                 name = itf.get("name", "")
                 stats = itf.get("statistics", {})
                 result[name] = {
+                    "in-packets": int(stats.get("in-packets", 0)),
+                    "out-packets": int(stats.get("out-packets", 0)),
                     "in-octets": int(stats.get("in-octets", 0)),
                     "out-octets": int(stats.get("out-octets", 0)),
                     "in-errors": int(stats.get("in-error-packets", 0)),
@@ -69,17 +71,22 @@ class InterfaceStatsMixin:
             out_err = s2[name]["out-errors"] - s1[name]["out-errors"]
             in_disc = s2[name]["in-discards"] - s1[name]["in-discards"]
             out_disc = s2[name]["out-discards"] - s1[name]["out-discards"]
-            if in_bps or out_bps:
-                rows.append(
-                    {
-                        "interface": name,
-                        "in-Kbps": round(in_bps / 1000, 1),
-                        "out-Kbps": round(out_bps / 1000, 1),
-                        "in-err": in_err,
-                        "out-err": out_err,
-                        "in-disc": in_disc,
-                        "out-disc": out_disc,
-                    }
-                )
+            # Cumulative counters are always reported (even for idle interfaces)
+            # so tests and agents can read raw packet/octet totals.
+            rows.append(
+                {
+                    "interface": name,
+                    "in-Kbps": round(in_bps / 1000, 1),
+                    "out-Kbps": round(out_bps / 1000, 1),
+                    "in-err": in_err,
+                    "out-err": out_err,
+                    "in-disc": in_disc,
+                    "out-disc": out_disc,
+                    "in-pkts": s2[name]["in-packets"],
+                    "out-pkts": s2[name]["out-packets"],
+                    "in-octets": s2[name]["in-octets"],
+                    "out-octets": s2[name]["out-octets"],
+                }
+            )
 
         return {"ifstats": rows}

--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -26,6 +26,7 @@ class RoutingMixin:
         route_fam: str,
         route_type: Optional[str] = "2",
         network_instance: str = "*",
+        detail: bool = False,
     ) -> Dict[str, Any]:
         BGP_RIB_MOD = "bgp-rib"
         BGP_RIB_MOD2 = "urn:nokia.com:srlinux:bgp:rib-bgp"
@@ -123,6 +124,46 @@ class RoutingMixin:
                             if "esi-label:" in x_comm
                         ]
                     )
+                    ext_comms = d.get("communities", {}).get("ext-community", [])
+                    # Site-of-Origin (SoO) carried as origin: ext-community
+                    d["_soo"] = ", ".join(
+                        [c.split("origin:")[1] for c in ext_comms if "origin:" in c]
+                    )
+                    # BGP tunnel-encap ext-community (e.g. VXLAN / MPLS)
+                    d["_tunnel_encap"] = ", ".join(
+                        [
+                            c.split("bgp-tunnel-encap:")[1]
+                            for c in ext_comms
+                            if "bgp-tunnel-encap:" in c
+                        ]
+                    )
+                    # Standard + large communities (RT/SoO/encap live in ext-comm)
+                    std_comms = d.get("communities", {}).get("community", []) or []
+                    large_comms = (
+                        d.get("communities", {}).get("large-community", []) or []
+                    )
+                    d["_communities"] = ", ".join(
+                        [str(c) for c in list(std_comms) + list(large_comms)]
+                    )
+                    # D-PATH (BGP domain-path) - collect all domain-ids in order
+                    dpath_ids: List[str] = []
+
+                    def _collect_domain_ids(obj: Any) -> None:
+                        if isinstance(obj, dict):
+                            for k, v in obj.items():
+                                if k == "domain-id":
+                                    if isinstance(v, list):
+                                        dpath_ids.extend(str(x) for x in v)
+                                    else:
+                                        dpath_ids.append(str(v))
+                                else:
+                                    _collect_domain_ids(v)
+                        elif isinstance(obj, list):
+                            for item in obj:
+                                _collect_domain_ids(item)
+
+                    _collect_domain_ids(d.get("domain-path", {}))
+                    d["_dpath"] = " ".join(dpath_ids)
                     return d
                 else:
                     return {k: augment_routes(v, attribs) for k, v in d.items()}
@@ -235,25 +276,57 @@ class RoutingMixin:
             },
         }
 
+        # Extra path-attribute fields appended to the per-route projection when
+        # detail=True. These are only added to structured (json/yaml) output so
+        # the table report stays lean. Keys are unique vs. the lean projections.
+        EXTRA_ATTRS_EVPN = (
+            'communities:"_communities", soo:"_soo", '
+            '"tunnel-encap":"_tunnel_encap", dpath:"_dpath", '
+            'valid:"valid-route", best:"best-route", used:"used-route", '
+            '"tie-break":"tie-break-reason", "internal-tags":"internal-tags", '
+            '"neighbor-as":"neighbor-as"'
+        )
+        EXTRA_ATTRS_IP = (
+            'soo:"_soo", "tunnel-encap":"_tunnel_encap", dpath:"_dpath", '
+            'valid:"valid-route", best:"best-route", used:"used-route", '
+            '"tie-break":"tie-break-reason", "internal-tags":"internal-tags", '
+            '"neighbor-as":"neighbor-as"'
+        )
+
+        def _with_detail(attrs: str, extra: str) -> str:
+            # The per-route projection ends with '}}' (closing the route dict and
+            # the enclosing NI dict). Inject extra fields into the route dict.
+            if detail and attrs.endswith("}}"):
+                return attrs[:-2] + ", " + extra + "}}"
+            return attrs
+
+        evpn_attrs = _with_detail(
+            RIB_EVPN_PATH_VERSIONS[evpn_path_version]["RIB_EVPN_JMESPATH_ATTRS"][
+                route_type
+            ],
+            EXTRA_ATTRS_EVPN,
+        )
+        ip_jmespath = _with_detail(
+            RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_JMESPATH"], EXTRA_ATTRS_IP
+        )
+
         PATH_SPECS = {
             "evpn": {
                 "path": RIB_EVPN_PATH_VERSIONS[evpn_path_version]["RIB_EVPN_PATH"],
                 "jmespath": RIB_EVPN_PATH_VERSIONS[evpn_path_version][
                     "RIB_EVPN_JMESPATH_COMMON"
                 ]
-                + RIB_EVPN_PATH_VERSIONS[evpn_path_version]["RIB_EVPN_JMESPATH_ATTRS"][
-                    route_type
-                ],
+                + evpn_attrs,
                 "datatype": "state",
             },
             "ipv4": {
                 "path": RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_PATH"],
-                "jmespath": RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_JMESPATH"],
+                "jmespath": ip_jmespath,
                 "datatype": "state",
             },
             "ipv6": {
                 "path": RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_PATH"],
-                "jmespath": RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_JMESPATH"],
+                "jmespath": ip_jmespath,
                 "datatype": "state",
             },
         }
@@ -572,6 +645,95 @@ class RoutingMixin:
 
         res = jmespath.search(path_spec["jmespath"], resp[0])
         return {"ip_rib": res}
+
+    def get_tunnel_table(self, network_instance: str = "*") -> Dict[str, Any]:
+        """Get the IP tunnel-table (LDP, SR-ISIS, RSVP, VXLAN, ...).
+
+        Resolves each tunnel's next-hop-group to the egress subinterface,
+        next-hop IP and pushed MPLS label-stack, mirroring the next-hop
+        resolution used by :meth:`get_rib`. Returns flat rows with the fields
+        required to verify transport/forwarding paths in tests.
+        """
+        # Build next-hop and next-hop-group lookups (per network-instance).
+        nhs = self.get(
+            paths=[
+                f"/network-instance[name={network_instance}]/route-table/next-hop[index=*]"
+            ],
+            datatype="state",
+        )
+        nhgroups = self.get(
+            paths=[
+                f"/network-instance[name={network_instance}]/route-table/next-hop-group[index=*]"
+            ],
+            datatype="state",
+        )
+
+        nh_mapping: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        for ni in nhs[0].get("network-instance", []):
+            tmp_map: Dict[str, Dict[str, Any]] = {}
+            for nh in ni.get("route-table", {}).get("next-hop", []):
+                label_stack = nh.get("mpls-encapsulation", {}).get(
+                    "pushed-mpls-label-stack"
+                ) or nh.get("mpls", {}).get("pushed-mpls-label-stack")
+                tmp_map[nh["index"]] = {
+                    "ip-address": nh.get("ip-address"),
+                    "subinterface": nh.get("subinterface"),
+                    "type": nh.get("type"),
+                    "labels": label_stack,
+                }
+            nh_mapping[ni["name"]] = tmp_map
+
+        nhgroup_mapping: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+        for ni in nhgroups[0].get("network-instance", []):
+            ni_name = ni["name"]
+            nh_map: Dict[str, List[Dict[str, Any]]] = {}
+            for nhgroup in ni.get("route-table", {}).get("next-hop-group", []):
+                nh_map[nhgroup["index"]] = [
+                    nh_mapping.get(ni_name, {}).get(nh.get("next-hop"), {})
+                    for nh in nhgroup.get("next-hop", [])
+                ]
+            nhgroup_mapping[ni_name] = nh_map
+
+        resp = self.get(
+            paths=[f"/network-instance[name={network_instance}]/tunnel-table"],
+            datatype="state",
+        )
+
+        rows: List[Dict[str, Any]] = []
+        for ni in resp[0].get("network-instance", []):
+            ni_name = ni["name"]
+            tunnel_table = ni.get("tunnel-table", {})
+            for afi in ("ipv4", "ipv6"):
+                prefix_key = "ipv4-prefix" if afi == "ipv4" else "ipv6-prefix"
+                for tunnel in tunnel_table.get(afi, {}).get("tunnel", []):
+                    nhg_index = tunnel.get("next-hop-group")
+                    resolved = nhgroup_mapping.get(ni_name, {}).get(nhg_index, [])
+                    next_hops = [
+                        nh.get("ip-address") for nh in resolved if nh.get("ip-address")
+                    ]
+                    egress_itfs = [
+                        nh.get("subinterface")
+                        for nh in resolved
+                        if nh.get("subinterface")
+                    ]
+                    labels = [
+                        str(lbl) for nh in resolved for lbl in (nh.get("labels") or [])
+                    ]
+                    rows.append(
+                        {
+                            "NI": ni_name,
+                            "Prefix": tunnel.get(prefix_key),
+                            "type": tunnel.get("type"),
+                            "owner": tunnel.get("owner"),
+                            "pref": tunnel.get("preference"),
+                            "metric": tunnel.get("metric"),
+                            "next-hop": next_hops,
+                            "egress-itf": egress_itfs,
+                            "label": labels,
+                        }
+                    )
+
+        return {"tunnel_table": rows}
 
     def get_routing_policies(self) -> Dict[str, Any]:
         """

--- a/nornir_srl/mcp_server.py
+++ b/nornir_srl/mcp_server.py
@@ -36,6 +36,7 @@ from nornir.core import Nornir
 from nornir.core.task import Result, Task
 
 from .connections.srlinux import CONNECTION_NAME
+from .connections.helpers import clean_structured_key
 
 logger = logging.getLogger(__name__)
 
@@ -258,7 +259,7 @@ def _extract_report_data(
                             merged = {**common, **sub_row}
                             if _pass_filter(merged, field_filter):
                                 rows.append({"Node": node_name, **merged})
-    return rows
+    return [{clean_structured_key(k): v for k, v in row.items()} for row in rows]
 
 
 def _run_report(
@@ -514,6 +515,12 @@ def bgp_rib(
 ) -> str:
     """Get BGP RIB (Routing Information Base) entries.
 
+    Returns the full set of path attributes for each route, including standard
+    communities, Site-of-Origin (soo), BGP domain-path (dpath), tunnel-encap
+    extended-community, route-target (RT), as-path, next-hop, and route status
+    (valid/best/used, tie-break reason, internal-tags). Useful for diagnosing
+    EVPN/IP-VPN loop-prevention and route-leaking issues.
+
     Args:
         route_fam: Route family - one of 'evpn', 'ipv4', 'ipv6'.
         route_type: Route type for EVPN (1-5). Only applicable when route_fam='evpn'.
@@ -526,7 +533,7 @@ def bgp_rib(
 
     def _task(task: Task) -> Result:
         device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
-        kwargs: Dict[str, Any] = {"route_fam": route_fam}
+        kwargs: Dict[str, Any] = {"route_fam": route_fam, "detail": True}
         if route_type is not None:
             kwargs["route_type"] = route_type
         return Result(host=task.host, result=device.get_bgp_rib(**kwargs))
@@ -614,6 +621,33 @@ def static_routes(
         return Result(host=task.host, result=device.get_static_routes())
 
     data = _run_report("static_routes", _task, i_filt, f_filt)
+    return json.dumps(data, indent=2, default=str)
+
+
+@mcp.tool()
+def tunnel_table(
+    inv_filter: Optional[str] = None,
+    field_filter: Optional[str] = None,
+) -> str:
+    """Get the IP tunnel-table from /network-instance[name=*]/tunnel-table.
+
+    Returns transport tunnels (LDP, SR-ISIS, RSVP, VXLAN, ...) with the
+    resolved egress interface, next-hop IP, pushed MPLS label-stack, tunnel
+    type, owner, metric and preference. Useful for verifying which transport
+    a remote endpoint (e.g. a loopback) is reached over, and on which port.
+
+    Args:
+        inv_filter: Inventory filter as comma-separated key=value pairs. Supports wildcards.
+            Matches against node labels from the topology file. Omit if no labels are defined.
+        field_filter: Field filter as comma-separated key=value pairs (e.g. 'type=ldp'). Supports regex.
+    """
+    i_filt, f_filt = _parse_filters(inv_filter, field_filter)
+
+    def _task(task: Task) -> Result:
+        device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+        return Result(host=task.host, result=device.get_tunnel_table())
+
+    data = _run_report("tunnel_table", _task, i_filt, f_filt)
     return json.dumps(data, indent=2, default=str)
 
 
@@ -876,9 +910,12 @@ def ifstats(
     """Get per-interface traffic rates (in/out bps) computed from two consecutive gNMI samples.
 
     Queries interface statistics twice with a configurable interval, then calculates
-    the delta to derive bits-per-second rates for each interface.
+    the delta to derive rates for each interface.
 
-    Returns interface name, in-bps, out-bps, in-Kbps, out-Kbps, in-Mbps, out-Mbps.
+    Returns per interface: in-Kbps/out-Kbps (rate over the interval), in-err/out-err
+    and in-disc/out-disc (deltas), plus cumulative counters in-pkts/out-pkts and
+    in-octets/out-octets. Idle interfaces are included so raw counters are always
+    available.
 
     Args:
         interval: Seconds between the two samples (default 5).

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,301 @@
+"""Unit tests for report helpers and getters added for DCI use-cases.
+
+These tests use small in-memory fixtures and a fake gNMI ``get`` so they run
+without a live device.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from nornir_srl.connections.helpers import clean_structured_key
+from nornir_srl.connections.routing import RoutingMixin
+
+# --------------------------------------------------------------------------- #
+# clean_structured_key
+# --------------------------------------------------------------------------- #
+
+
+def test_clean_structured_key_strips_order_prefix():
+    assert clean_structured_key("0_st") == "st"
+    assert clean_structured_key("1_peer") == "peer"
+    assert clean_structured_key("10_foo") == "foo"
+
+
+def test_clean_structured_key_collapses_newlines():
+    assert clean_structured_key("AF: EVPN\nRx/Act/Tx") == "AF: EVPN Rx/Act/Tx"
+
+
+def test_clean_structured_key_leaves_plain_keys():
+    assert clean_structured_key("Node") == "Node"
+    assert clean_structured_key("next-hop") == "next-hop"
+
+
+def test_clean_structured_key_passthrough_non_str():
+    assert clean_structured_key(5) == 5
+    assert clean_structured_key(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Fake device wiring
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRouting(RoutingMixin):
+    """RoutingMixin with a scripted ``get`` keyed on path substrings."""
+
+    def __init__(self, responses: Dict[str, List[Dict[str, Any]]]):
+        self._responses = responses
+        self.capabilities = {
+            "supported_models": [{"name": "bgp-rib", "version": "2024-10-31"}]
+        }
+
+    def get(
+        self,
+        paths: List[str],
+        datatype: Optional[str] = "config",
+        strip_mod: Optional[bool] = True,
+    ) -> List[Dict[str, Any]]:
+        path = paths[0]
+        for key, resp in self._responses.items():
+            if key in path:
+                return resp
+        raise KeyError(f"no scripted response for path {path}")
+
+
+# --------------------------------------------------------------------------- #
+# get_bgp_rib path attributes (detail=True)
+# --------------------------------------------------------------------------- #
+
+
+def test_get_bgp_rib_evpn_detail_attributes():
+    attr_sets = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {
+                        "attr-sets": {
+                            "attr-set": [
+                                {
+                                    "index": 1,
+                                    "origin": "igp",
+                                    "as-path": {"segment": [{"member": [65000]}]},
+                                    "communities": {
+                                        "community": ["65000:1"],
+                                        "ext-community": [
+                                            "target:65000:100",
+                                            "origin:65000:1",
+                                            "bgp-tunnel-encap:MPLS",
+                                        ],
+                                    },
+                                    "domain-path": {
+                                        "domain-segment": [
+                                            {"domain": {"domain-id": ["65000:1"]}}
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+    ]
+    routes = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {
+                        "afi-safi": [
+                            {
+                                "evpn": {
+                                    "rib-in-out": {
+                                        "rib-in-post": {
+                                            "mac-ip-route": [
+                                                {
+                                                    "attr-id": 1,
+                                                    "used-route": True,
+                                                    "valid-route": True,
+                                                    "best-route": True,
+                                                    "neighbor": "192.0.2.2",
+                                                    "neighbor-as": 65002,
+                                                    "tie-break-reason": "none",
+                                                    "internal-tags": [
+                                                        "tag-value = 0x1"
+                                                    ],
+                                                    "route-distinguisher": "192.0.2.2:100",
+                                                    "esi": "00:00:00:00:00:00:00:00:00:00",
+                                                    "mac-address": "1A:DC:0E:FF:00:41",
+                                                    "ip-address": "10.0.0.1",
+                                                    "next-hop": "192.0.2.2",
+                                                    "label": {"value": 100},
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    ]
+
+    dev = _FakeRouting({"attr-sets/attr-set": attr_sets, "mac-ip-route": routes})
+    out = dev.get_bgp_rib(route_fam="evpn", route_type="2", detail=True)
+    rib = out["bgp_rib"]
+    assert len(rib) == 1
+    route = rib[0]["Rib"][0]
+    assert route["RT"] == "65000:100"
+    assert route["soo"] == "65000:1"
+    assert route["tunnel-encap"] == "MPLS"
+    assert route["dpath"] == "65000:1"
+    assert route["communities"] == "65000:1"
+    assert route["valid"] is True and route["best"] is True and route["used"] is True
+    assert route["tie-break"] == "none"
+    assert route["internal-tags"] == ["tag-value = 0x1"]
+    assert route["neighbor-as"] == 65002
+
+
+def test_get_bgp_rib_evpn_lean_has_no_extra_attrs():
+    """Without detail, the lean projection must not include the extra fields."""
+    attr_sets = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {"attr-sets": {"attr-set": [{"index": 1}]}},
+                }
+            ]
+        }
+    ]
+    routes = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {
+                        "afi-safi": [
+                            {
+                                "evpn": {
+                                    "rib-in-out": {
+                                        "rib-in-post": {
+                                            "mac-ip-route": [
+                                                {
+                                                    "attr-id": 1,
+                                                    "used-route": True,
+                                                    "valid-route": True,
+                                                    "best-route": True,
+                                                    "neighbor": "192.0.2.2",
+                                                    "route-distinguisher": "192.0.2.2:100",
+                                                    "esi": "00:00:00:00:00:00:00:00:00:00",
+                                                    "mac-address": "1A:DC:0E:FF:00:41",
+                                                    "ip-address": "10.0.0.1",
+                                                    "next-hop": "192.0.2.2",
+                                                    "label": {"value": 100},
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    ]
+    dev = _FakeRouting({"attr-sets/attr-set": attr_sets, "mac-ip-route": routes})
+    out = dev.get_bgp_rib(route_fam="evpn", route_type="2", detail=False)
+    route = out["bgp_rib"][0]["Rib"][0]
+    assert "soo" not in route
+    assert "dpath" not in route
+    assert "communities" not in route
+
+
+# --------------------------------------------------------------------------- #
+# get_tunnel_table next-hop resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_get_tunnel_table_resolves_egress_and_label():
+    next_hops = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "route-table": {
+                        "next-hop": [
+                            {
+                                "index": "10",
+                                "type": "mpls",
+                                "ip-address": "10.255.0.1",
+                                "subinterface": "ethernet-1/5.0",
+                                "mpls-encapsulation": {
+                                    "pushed-mpls-label-stack": [20000]
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    ]
+    next_hop_groups = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "route-table": {
+                        "next-hop-group": [
+                            {"index": "77", "next-hop": [{"next-hop": "10"}]}
+                        ]
+                    },
+                }
+            ]
+        }
+    ]
+    tunnel_table = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "tunnel-table": {
+                        "ipv4": {
+                            "tunnel": [
+                                {
+                                    "ipv4-prefix": "192.0.2.152/32",
+                                    "type": "ldp",
+                                    "owner": "ldp_mgr",
+                                    "id": 65537,
+                                    "next-hop-group": "77",
+                                    "metric": 10,
+                                    "preference": 9,
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+    ]
+
+    dev = _FakeRouting(
+        {
+            "next-hop-group[index=*]": next_hop_groups,
+            "next-hop[index=*]": next_hops,
+            "tunnel-table": tunnel_table,
+        }
+    )
+    out = dev.get_tunnel_table()
+    rows = out["tunnel_table"]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["Prefix"] == "192.0.2.152/32"
+    assert row["type"] == "ldp"
+    assert row["pref"] == 9
+    assert row["metric"] == 10
+    assert row["next-hop"] == ["10.255.0.1"]
+    assert row["egress-itf"] == ["ethernet-1/5.0"]
+    assert row["label"] == ["20000"]


### PR DESCRIPTION
## Summary

These changes were driven by a Datacenter-Interconnect (EVPN-VXLAN <-> EVPN-MPLS/IP-VPN) test suite where the existing `fcli` reports forced a fallback to raw `sr_cli` parsing. Four improvements:

### 1. New `tunnel-table` report
- `fcli tunnel-table` (and an `fcli-mcp` tool) showing transport tunnels (LDP, SR-ISIS, RSVP, VXLAN, ...).
- Resolves each tunnel's `next-hop-group` -> `next-hop` to surface the **egress sub-interface**, **next-hop IP** and **pushed MPLS label-stack**, reusing the same resolution `get_rib` already does.
- Fields: `NI, Prefix, type, owner, pref, metric, next-hop, egress-itf, label`.

### 2. `bgp-rib` path attributes (lean table vs full structured output)
- The table keeps a curated set of priority fields so it stays readable.
- Non-table output (`-o json|yaml|csv`) and the MCP tool now include the **full** set of path attributes per route: standard `communities`, Site-of-Origin (`soo`), BGP domain-path (`dpath`), `tunnel-encap` ext-community, route status (`valid`/`best`/`used`), `tie-break` reason, `internal-tags`, `neighbor-as` (in addition to the existing `RT`, `as-path`, `next-hop`, ...).
- New `--detail/-d` flag opts the table into the full set too. This is invaluable for diagnosing EVPN/IP-VPN loop-prevention and route-leaking.

### 3. `ifstats` cumulative counters
- Adds cumulative `in-pkts`/`out-pkts` and `in-octets`/`out-octets` alongside the existing interval rates.
- Idle interfaces are no longer dropped, so raw counters are always available to tests/agents.

### 4. JSON-schema cleanup
- Field names like `0_st` and `1_peer` exist only to drive table column ordering, and multi-line headers embed `\n` (e.g. `"AF: EVPN\nRx/Act/Tx"`). A new `clean_structured_key` helper strips the `<n>_` ordering prefix and collapses newlines **for structured output only** (json/yaml/csv and MCP). Table ordering is unchanged.

## Examples

```
fcli tunnel-table -f type=ldp
fcli -o json bgp-rib -r evpn -t 5      # full attributes
fcli -d bgp-rib -r evpn -t 5           # full attributes in the table too
fcli -o json ifstats                   # includes cumulative counters
```

bgp-rib `-o json` route (note clean `st` key + new attributes):
```json
{
  "st": "u*>", "RT": "65000:100", "soo": "65000:2", "tunnel-encap": "MPLS",
  "dpath": "", "valid": true, "best": true, "used": true,
  "tie-break": "none", "internal-tags": ["tag-value = 0x2"], "neighbor-as": 65000
}
```

## Test plan
- [x] `pytest` (existing + new unit tests for `clean_structured_key`, bgp-rib attribute extraction, tunnel-table next-hop resolution)
- [x] `mypy` clean on touched modules
- [x] `black` formatted
- [x] Live smoke tests against a multi-DC SR Linux containerlab fabric: `tunnel-table`, `bgp-rib -r evpn -t 2/5 -o json`, `bgp-peers -o json`, `ifstats -o json` (table stays lean; structured output carries full/clean schema)

## Notes
- This release of the SR Linux model has no explicit `invalid-reason` leaf; `valid`/`best`/`used` + `tie-break` reason are the equivalent and are now exposed.
- Version not bumped; happy to bump via `.bumpversion.cfg` if preferred.

Made with [Cursor](https://cursor.com)