### PR TITLE
fcli: L3VPN BGP RIB and BGP peer L3VPN AFI columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,9 @@ Options:
                                 pattern>, e.g. -f state=up -f
                                 admin_state="ena.*". Fieldnames correspond to
                                 column names of a report
-  -r, --route-fam [evpn|ipv4]   Route family for BGP RIB  [required]
+  -r, --route-fam TEXT          evpn | ipv4 | ipv6 | l3vpn-v4 | l3vpn-v6 (IP-VPN
+                                unicast; full names l3vpn-ipv4-unicast /
+                                l3vpn-ipv6-unicast also accepted)  [required]
   -t, --route-type [1|2|3|4|5]  Route type for EVPN routes
   --help                        Show this message and exit.
 ```
@@ -275,7 +277,7 @@ Optionally, you can specify filters to control the output. There are 2 types of 
 
 - inventory filters, specified with the global `-i` option, filter on the inventory, e.g. `-i hostname=clab-4l2s-l1`  or `-i role=leaf` based on inventory data
 - field filters, specified with the report-specific `-f` option. This filters based on the fields shown in the report and a regex pattern, e.g. `-f state="esta.*"`. Multiple field filters can be specified by repeated `-f` options
-- report-specific options are options specific to a report, if applicable. Currently, the only report that needs extra arguments is 'bgp-rib', i.e. `route_fam=evpn|ipv4|ipv6` and `route_type=1|2|3|4|5`. The latter relates to EVPN route-trypes and is optional. Defaults to '2' (mac-ip-routes). 
+- report-specific options are options specific to a report, if applicable. Currently, the only report that needs extra arguments is 'bgp-rib', i.e. `route_fam=evpn|ipv4|ipv6|l3vpn-v4|l3vpn-v6` (or the long `l3vpn-*-unicast` names) and `route_type=1|2|3|4|5` for EVPN only. The latter relates to EVPN route-types and is optional. Defaults to '2' (mac-ip-routes). 
 
 ## Examples
 
@@ -307,19 +309,19 @@ Show all BGP peers on all nodes that are in state `active`:
 ```
                                                                   BGP Peers                                                                   
                                                       Fields filter:{'state': 'active'}                                                       
-+--------------------------------------------------------------------------------------------------------------------------------------------+
-|              |           |                 | AFI/SAFI  | AFI/SAFI  |               |         |               |          |         |        |
-|              |           |                 | EVPN      | IPv4-UC   |               |         |               |          |         |        |
-| Node         | NI        | 1_peer          | Rx/Act/Tx | Rx/Act/Tx | export_policy | group   | import_policy | local_as | peer_as | state  |
-|--------------+-----------+-----------------+-----------+-----------+---------------+---------+---------------+----------+---------+--------|
-| clab-4l2s-l4 | ipvrf-200 | 10.200.4.100    | disabled  | down      | v200-out      | clients |               | 6848     | 65534   | active |
-|--------------+-----------+-----------------+-----------+-----------+---------------+---------+---------------+----------+---------+--------|
-| clab-4l2s-s1 | default   | 192.168.0.225   | disabled  | down      | pass-all      | dcgw    | pass-all      | 65100    | 65200   | active |
-|              |           | 192.168.255.201 | 0/0/0     | disabled  | pass-evpn     | overlay | pass-evpn     | 100      | 100     | active |
-|--------------+-----------+-----------------+-----------+-----------+---------------+---------+---------------+----------+---------+--------|
-| clab-4l2s-s2 | default   | 192.168.0.229   | disabled  | down      | pass-all      | dcgw    | pass-all      | 65100    | 65200   | active |
-|              |           | 192.168.0.231   | disabled  | down      | pass-all      | dcgw    | pass-all      | 65100    | 65201   | active |
-+--------------------------------------------------------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              |           |                 | U4 R/A/T | U6 R/A/T | EV R/A/T | V4 R/A/T | V6 R/A/T |               |         |               |          |         |        |
+| Node         | NI        | 1_peer          |          |          |          |          |          | export_policy | group   | import_policy | local_as | peer_as | state  |
+|--------------+-----------+-----------------+----------+----------+----------+----------+----------+---------------+---------+---------------+----------+---------+--------|
+| clab-4l2s-l4 | ipvrf-200 | 10.200.4.100    | disabled | -        | disabled | -        | -        | v200-out      | clients |               | 6848     | 65534   | active |
+|--------------+-----------+-----------------+----------+----------+----------+----------+----------+---------------+---------+---------------+----------+---------+--------|
+| clab-4l2s-s1 | default   | 192.168.0.225   | disabled | -        | disabled | -        | -        | pass-all      | dcgw    | pass-all      | 65100    | 65200   | active |
+|              |           | 192.168.255.201 | disabled | -        | 0/0/0    | -        | -        | pass-evpn     | overlay | pass-evpn     | 100      | 100     | active |
++---------------------------------------------------------------------------------------------------------------------------------------------------------+
+```
+
+Column keys: **U4** = IPv4 unicast, **U6** = IPv6 unicast, **EV** = EVPN, **V4** = L3VPN IPv4, **V6** = L3VPN IPv6 (values are received / active / sent, `disabled`, `down`, or `-`).
+
 ```
 
 ### ipv4-rib
@@ -403,6 +405,11 @@ Show all EVPN RT=2 routes for MAC address that starts with "1A:DC":
 | clab-4l2s-s2 | default | *>   | 01:24:24:24:24:24:24:00:00:01 | 10.200.1.10 | 1A:DC:0E:FF:00:41 | 192.168.255.2:202 | i       | 192.168.255.2 | igp    | 192.168.255.2   | 202 |
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
+
+VPN-IPv4 / VPN-IPv6 BGP RIB (per network-instance) use **RD** and **Pfx** columns instead of a single `Prefix` field:
+
+`fcli bgp-rib -r l3vpn-v4 -f Pfx="10.*"`  
+`fcli bgp-rib -r l3vpn-v6`  (same as `-r l3vpn-ipv6-unicast`)
 
 #### bgp-rib path attributes
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ VPN-IPv4 / VPN-IPv6 BGP RIB (per network-instance) use **RD** and **Pfx** column
 `fcli bgp-rib -r l3vpn-v4 -f Pfx="10.*"`  
 `fcli bgp-rib -r l3vpn-v6`  (same as `-r l3vpn-ipv6-unicast`)
 
+Nodes that do not expose the L3VPN RIB gNMI path (for example EVPN-only leaves) contribute **no rows** for that family instead of failing the whole report.
+
 #### bgp-rib path attributes
 
 The `bgp-rib` table shows a curated set of priority fields so it stays readable.

--- a/README.md
+++ b/README.md
@@ -310,9 +310,10 @@ Show all BGP peers on all nodes that are in state `active`:
                                                                   BGP Peers                                                                   
                                                       Fields filter:{'state': 'active'}                                                       
 +---------------------------------------------------------------------------------------------------------------------------------------------------------+
-|              |           |                 | U4 R/A/T | U6 R/A/T | EV R/A/T | V4 R/A/T | V6 R/A/T |               |         |               |          |         |        |
-| Node         | NI        | 1_peer          |          |          |          |          |          | export_policy | group   | import_policy | local_as | peer_as | state  |
-|--------------+-----------+-----------------+----------+----------+----------+----------+----------+---------------+---------+---------------+----------+---------+--------|
+|              |           |                 | U4    | U6    | EVPN  | VPNv4 | VPNv6 |               |         |               |          |         |        |
+|              |           |                 | R/A/T | R/A/T | R/A/T | R/A/T | R/A/T |               |         |               |          |         |        |
+| Node         | NI        | 1_peer          |       |       |       |       |       | export_policy | group   | import_policy | local_as | peer_as | state  |
+|--------------+-----------+-----------------+-------+-------+-------+-------+-------+---------------+---------+---------------+----------+---------+--------|
 | clab-4l2s-l4 | ipvrf-200 | 10.200.4.100    | disabled | -        | disabled | -        | -        | v200-out      | clients |               | 6848     | 65534   | active |
 |--------------+-----------+-----------------+----------+----------+----------+----------+----------+---------------+---------+---------------+----------+---------+--------|
 | clab-4l2s-s1 | default   | 192.168.0.225   | disabled | -        | disabled | -        | -        | pass-all      | dcgw    | pass-all      | 65100    | 65200   | active |
@@ -320,9 +321,7 @@ Show all BGP peers on all nodes that are in state `active`:
 +---------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
-Column keys: **U4** = IPv4 unicast, **U6** = IPv6 unicast, **EV** = EVPN, **V4** = L3VPN IPv4, **V6** = L3VPN IPv6 (values are received / active / sent, `disabled`, `down`, or `-`).
-
-```
+Column headers use two lines in the live table (AFI label, then **R/A/T**). **U4** / **U6** = IPv4/IPv6 unicast, **EVPN**, **VPNv4** / **VPNv6** = L3VPN address families (values are received / active / sent, `disabled`, `down`, or `-`). JSON/YAML/CSV keys collapse the newline to a single space.
 
 ### ipv4-rib
 

--- a/nornir_srl/cli.py
+++ b/nornir_srl/cli.py
@@ -22,6 +22,7 @@ from nornir.core.task import Result, Task, AggregatedResult
 from nornir.core.inventory import Host
 
 from .connections.srlinux import CONNECTION_NAME
+from .connections.routing import BGP_RIB_ROUTE_FAM_ALIASES
 from .connections.helpers import clean_structured_key
 from .utils.logging_config import setup_logging
 from . import __version__
@@ -723,7 +724,12 @@ def tunnel_table(
 def bgp_rib(
     ctx: typer.Context,
     route_fam: str = typer.Option(
-        ..., "--route-fam", "-r", help="Route family", case_sensitive=False
+        ...,
+        "--route-fam",
+        "-r",
+        help="evpn | ipv4 | ipv6 | l3vpn-v4 | l3vpn-v6 (IP-VPN unicast; full names "
+        "l3vpn-ipv4-unicast / l3vpn-ipv6-unicast also accepted)",
+        case_sensitive=False,
     ),
     route_type: Optional[str] = typer.Option(
         None, "--route-type", "-t", help="Route type for EVPN"
@@ -748,7 +754,8 @@ def bgp_rib(
             kwargs["route_type"] = route_type
         return Result(host=task.host, result=device.get_bgp_rib(**kwargs))
 
-    run_show(ctx, "bgp_rib", _bgp_rib, field_filter)
+    rib_title = "BGP RIB (" + BGP_RIB_ROUTE_FAM_ALIASES.get(route_fam.lower(), route_fam) + ")"
+    run_show(ctx, "bgp_rib", _bgp_rib, field_filter, title=rib_title)
 
 
 @app.command()

--- a/nornir_srl/cli.py
+++ b/nornir_srl/cli.py
@@ -754,7 +754,9 @@ def bgp_rib(
             kwargs["route_type"] = route_type
         return Result(host=task.host, result=device.get_bgp_rib(**kwargs))
 
-    rib_title = "BGP RIB (" + BGP_RIB_ROUTE_FAM_ALIASES.get(route_fam.lower(), route_fam) + ")"
+    rib_title = (
+        "BGP RIB (" + BGP_RIB_ROUTE_FAM_ALIASES.get(route_fam.lower(), route_fam) + ")"
+    )
     run_show(ctx, "bgp_rib", _bgp_rib, field_filter, title=rib_title)
 
 

--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -17,6 +17,39 @@ BGP_RIB_ROUTE_FAM_ALIASES: Dict[str, str] = {
 }
 
 
+def _gnmi_path_missing(exc: BaseException) -> bool:
+    """True when a gNMI Get failed because the path does not exist on the device."""
+    try:
+        import grpc
+
+        missing = (
+            grpc.StatusCode.NOT_FOUND,
+            grpc.StatusCode.INVALID_ARGUMENT,
+            grpc.StatusCode.UNIMPLEMENTED,
+        )
+    except ImportError:  # pragma: no cover
+        return False
+
+    chain: List[Optional[BaseException]] = [exc]
+    if exc.__cause__ is not None:
+        chain.append(exc.__cause__)
+    if exc.__context__ is not None and exc.__context__ is not exc.__cause__:
+        chain.append(exc.__context__)
+
+    for cur in chain:
+        if cur is None:
+            continue
+        code_fn = getattr(cur, "code", None)
+        if not callable(code_fn):
+            continue
+        try:
+            if code_fn() in missing:
+                return True
+        except Exception:
+            continue
+    return False
+
+
 class RoutingMixin:
     """Mixin providing routing and BGP related getters."""
 
@@ -410,9 +443,16 @@ class RoutingMixin:
                 attribs[ni["name"]].update({path_copy.pop("index"): path_copy})
 
         path_spec: Dict[str, str] = PATH_SPECS[route_fam]
-        resp = self.get(
-            paths=[str(path_spec.get("path"))], datatype=path_spec["datatype"]
-        )
+        rib_path = str(path_spec.get("path"))
+        try:
+            resp = self.get(paths=[rib_path], datatype=path_spec["datatype"])
+        except BaseException as e:
+            # Leaves / platforms without IP-VPN have no l3vpn-* RIB path; skip instead of failing.
+            if route_fam in ("l3vpn-ipv4-unicast", "l3vpn-ipv6-unicast") and _gnmi_path_missing(
+                e
+            ):
+                return {"bgp_rib": []}
+            raise
         for ni in resp[0].get("network-instance", []):
             ni = augment_routes(ni, attribs[ni["name"]])
 

--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -6,6 +6,16 @@ import copy
 import jmespath
 from .helpers import lpm
 
+# CLI / API aliases (e.g. ``-r l3vpn-v4``) → YANG ``afi-safi-name`` used in paths.
+BGP_RIB_ROUTE_FAM_ALIASES: Dict[str, str] = {
+    "l3vpn-v4": "l3vpn-ipv4-unicast",
+    "l3vpn-ipv4": "l3vpn-ipv4-unicast",
+    "l3vpn-ipv4-unicast": "l3vpn-ipv4-unicast",
+    "l3vpn-v6": "l3vpn-ipv6-unicast",
+    "l3vpn-ipv6": "l3vpn-ipv6-unicast",
+    "l3vpn-ipv6-unicast": "l3vpn-ipv6-unicast",
+}
+
 
 class RoutingMixin:
     """Mixin providing routing and BGP related getters."""
@@ -39,6 +49,8 @@ class RoutingMixin:
         else:
             raise Exception("Cannot get gNMI capabilities")
 
+        route_fam = BGP_RIB_ROUTE_FAM_ALIASES.get(route_fam.lower(), route_fam)
+
         BGP_EVPN_VERSION_MAP = {
             1: ("2021-", "2022-", "2023-", "2024-03", "2024-07"),
             2: ("20"),
@@ -56,6 +68,8 @@ class RoutingMixin:
             "evpn": "evpn",
             "ipv4": "ipv4-unicast",
             "ipv6": "ipv6-unicast",
+            "l3vpn-ipv4-unicast": "l3vpn-ipv4-unicast",
+            "l3vpn-ipv6-unicast": "l3vpn-ipv6-unicast",
         }
         ROUTE_TYPE_VERSIONS = {
             1: {
@@ -241,6 +255,50 @@ class RoutingMixin:
                 },
             },
         }
+        if route_fam in ("l3vpn-ipv4-unicast", "l3vpn-ipv6-unicast"):
+            # Hyphenated YANG leaf names must be JMESPath quoted identifiers, not bare tokens.
+            _pfx_q = (
+                "ipv4-prefix"
+                if route_fam == "l3vpn-ipv4-unicast"
+                else "ipv6-prefix"
+            )
+            ip_rib_jmespath_tail = {
+                1: (
+                    f'.{{neighbor:neighbor, "0_st":"_r_state", "RD":"route-distinguisher", '
+                    f'"Pfx":"{_pfx_q}", "lpref":"local-pref", med:med, "next-hop":"next-hop",'
+                    f'"as-path":"as-path".segment[0].member}}'
+                ),
+                2: (
+                    f'.{{neighbor:neighbor, "0_st":"_r_state", "RD":"route-distinguisher", '
+                    f'"Pfx":"{_pfx_q}", "lpref":"local-pref", med:med, "next-hop":"next-hop",'
+                    f'"as-path":"as-path".segment[0].member,'
+                    '"communities":[communities.community, communities."large-community"][]|join(\', \',@)}}'
+                ),
+                3: (
+                    f'.{{neighbor:neighbor, "0_st":"_r_state", "RD":"route-distinguisher", '
+                    f'"Pfx":"{_pfx_q}", "lpref":"local-pref", med:med, "next-hop":"next-hop",'
+                    f'"as-path":"as-path".segment[0].member,'
+                    '"communities":[communities.community, communities."large-community"][]|join(\',\',@)}}'
+                ),
+            }
+        else:
+            ip_rib_jmespath_tail = {
+                1: (
+                    '.{neighbor:neighbor, "0_st":"_r_state", "Prefix":prefix, "lpref":"local-pref", med:med, '
+                    '"next-hop":"next-hop","as-path":"as-path".segment[0].member}}'
+                ),
+                2: (
+                    '.{neighbor:neighbor, "0_st":"_r_state", "Prefix":prefix, "lpref":"local-pref", med:med, '
+                    '"next-hop":"next-hop","as-path":"as-path".segment[0].member,'
+                    '"communities":[communities.community, communities."large-community"][]|join(\', \',@)}}'
+                ),
+                3: (
+                    '.{neighbor:neighbor, "0_st":"_r_state", "Prefix":prefix, "lpref":"local-pref", med:med, '
+                    '"next-hop":"next-hop","as-path":"as-path".segment[0].member,'
+                    '"communities":[communities.community, communities."large-community"][]|join(\',\',@)}}'
+                ),
+            }
+
         RIB_IP_PATH_VERSIONS = {
             1: {
                 "RIB_IP_PATH": (
@@ -250,7 +308,7 @@ class RoutingMixin:
                 "RIB_IP_JMESPATH": '"network-instance"[].{NI:name, Rib:"bgp-rib"."'
                 + ROUTE_FAMILY[route_fam]
                 + '"."local-rib"."routes"[]'
-                + '.{neighbor:neighbor, "0_st":"_r_state", "Prefix":prefix, "lpref":"local-pref", med:med, "next-hop":"next-hop","as-path":"as-path".segment[0].member}}',
+                + ip_rib_jmespath_tail[1],
             },
             2: {
                 "RIB_IP_PATH": (
@@ -260,8 +318,7 @@ class RoutingMixin:
                 "RIB_IP_JMESPATH": '"network-instance"[].{NI:name, Rib:"bgp-rib"."afi-safi"[]."'
                 + ROUTE_FAMILY[route_fam]
                 + '"."local-rib"."routes"[]'
-                + '.{neighbor:neighbor, "0_st":"_r_state", "Prefix":prefix, "lpref":"local-pref", med:med, "next-hop":"next-hop","as-path":"as-path".segment[0].member,\
-                      "communities":[communities.community, communities."large-community"][]|join(\', \',@)}}',
+                + ip_rib_jmespath_tail[2],
             },
             3: {
                 "RIB_IP_PATH": (
@@ -271,8 +328,7 @@ class RoutingMixin:
                 "RIB_IP_JMESPATH": '"network-instance"[].{NI:name, Rib:"bgp-rib"."afi-safi"[]."'
                 + ROUTE_FAMILY[route_fam]
                 + '"."local-rib"."route"[]'
-                + '.{neighbor:neighbor, "0_st":"_r_state", "Prefix":prefix, "lpref":"local-pref", med:med, "next-hop":"next-hop","as-path":"as-path".segment[0].member,\
-                      "communities":[communities.community, communities."large-community"][]|join(\',\',@)}}',
+                + ip_rib_jmespath_tail[3],
             },
         }
 
@@ -325,6 +381,16 @@ class RoutingMixin:
                 "datatype": "state",
             },
             "ipv6": {
+                "path": RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_PATH"],
+                "jmespath": ip_jmespath,
+                "datatype": "state",
+            },
+            "l3vpn-ipv4-unicast": {
+                "path": RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_PATH"],
+                "jmespath": ip_jmespath,
+                "datatype": "state",
+            },
+            "l3vpn-ipv6-unicast": {
                 "path": RIB_IP_PATH_VERSIONS[ip_path_version]["RIB_IP_PATH"],
                 "jmespath": ip_jmespath,
                 "datatype": "state",
@@ -394,6 +460,10 @@ class RoutingMixin:
                                     peer_data["ipv4-unicast"] = afi
                                 elif afi["afi-safi-name"] == "ipv6-unicast":
                                     peer_data["ipv6-unicast"] = afi
+                                elif afi["afi-safi-name"] == "l3vpn-ipv4-unicast":
+                                    peer_data["l3vpn-ipv4-unicast"] = afi
+                                elif afi["afi-safi-name"] == "l3vpn-ipv6-unicast":
+                                    peer_data["l3vpn-ipv6-unicast"] = afi
                         peer["_local-asn"] = peer_data["local-as"]
                         peer["_flags"] = ""
                         peer["_flags"] += (
@@ -461,14 +531,70 @@ class RoutingMixin:
                                 peer["_ipv6"] = "disabled"
                         else:
                             peer["_ipv6"] = "-"
+                        if peer_data.get("l3vpn-ipv4-unicast"):
+                            if peer_data["l3vpn-ipv4-unicast"]["admin-state"] == "enable":
+                                peer["_l3vpn4"] = (
+                                    str(
+                                        peer_data["l3vpn-ipv4-unicast"][
+                                            "received-routes"
+                                        ]
+                                    )
+                                    + "/"
+                                    + str(
+                                        peer_data["l3vpn-ipv4-unicast"][
+                                            "active-routes"
+                                        ]
+                                    )
+                                    + "/"
+                                    + str(
+                                        peer_data["l3vpn-ipv4-unicast"]["sent-routes"]
+                                    )
+                                )
+                                if (
+                                    peer_data["l3vpn-ipv4-unicast"].get("oper-state")
+                                    == "down"
+                                ):
+                                    peer["_l3vpn4"] = "down"
+                            else:
+                                peer["_l3vpn4"] = "disabled"
+                        else:
+                            peer["_l3vpn4"] = "-"
+                        if peer_data.get("l3vpn-ipv6-unicast"):
+                            if peer_data["l3vpn-ipv6-unicast"]["admin-state"] == "enable":
+                                peer["_l3vpn6"] = (
+                                    str(
+                                        peer_data["l3vpn-ipv6-unicast"][
+                                            "received-routes"
+                                        ]
+                                    )
+                                    + "/"
+                                    + str(
+                                        peer_data["l3vpn-ipv6-unicast"][
+                                            "active-routes"
+                                        ]
+                                    )
+                                    + "/"
+                                    + str(
+                                        peer_data["l3vpn-ipv6-unicast"]["sent-routes"]
+                                    )
+                                )
+                                if (
+                                    peer_data["l3vpn-ipv6-unicast"].get("oper-state")
+                                    == "down"
+                                ):
+                                    peer["_l3vpn6"] = "down"
+                            else:
+                                peer["_l3vpn6"] = "disabled"
+                        else:
+                            peer["_l3vpn6"] = "-"
 
         path_spec = {
             "path": f"/network-instance[name={network_instance}]/protocols/bgp/neighbor",
             "jmespath": '"network-instance"[].{NI:name, Neighbors: protocols.bgp.neighbor[].{"1_peer":"peer-address",\
                     "peer-as":"peer-as", state:"session-state","local-as":"_local-asn",flags:"_flags",\
                     "group":"peer-group", "export-policy":"export-policy", "import-policy":"import-policy",\
-                    "AF: IPv4\\nRx/Act/Tx":"_ipv4", "AF: IPv6\\nRx/Act/Tx":"_ipv6", \
-                    "AF: EVPN\\nRx/Act/Tx":"_evpn"}}',
+                    "U4 R/A/T":"_ipv4", "U6 R/A/T":"_ipv6", "EV R/A/T":"_evpn", \
+                    "V4 R/A/T":"_l3vpn4", "V6 R/A/T":"_l3vpn6"}}',
             "datatype": "all",
             "key": "index",
         }

--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -1,9 +1,14 @@
 # Routing related methods extracted from srlinux.py
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
 import copy
+import logging
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
 import jmespath
+
 from .helpers import lpm
 
 # CLI / API aliases (e.g. ``-r l3vpn-v4``) → YANG ``afi-safi-name`` used in paths.
@@ -15,6 +20,48 @@ BGP_RIB_ROUTE_FAM_ALIASES: Dict[str, str] = {
     "l3vpn-ipv6": "l3vpn-ipv6-unicast",
     "l3vpn-ipv6-unicast": "l3vpn-ipv6-unicast",
 }
+
+_pygnmi_suppress_lock = threading.Lock()
+_pygnmi_suppress_depth = 0
+_pygnmi_suppress_saved: Tuple[List[logging.Handler], int, bool] | None = None
+
+
+@contextmanager
+def _suppress_pygnmi_client_logging() -> Iterator[None]:
+    """Silence pygnmi's pre-raise CRITICAL log for expected invalid-path Get failures.
+
+    pygnmi attaches a StreamHandler to ``pygnmi.client`` with a low handler level,
+    so raising the logger level alone is not always enough to suppress output.
+
+    fcli queries many hosts concurrently; without a refcount, one task could
+    restore handlers while another host's L3VPN Get was still running, letting
+    GRPC noise leak back onto stderr/stdout.
+    """
+    global _pygnmi_suppress_depth, _pygnmi_suppress_saved
+    log = logging.getLogger("pygnmi.client")
+    with _pygnmi_suppress_lock:
+        _pygnmi_suppress_depth += 1
+        if _pygnmi_suppress_depth == 1:
+            _pygnmi_suppress_saved = (
+                list(log.handlers),
+                log.level,
+                log.propagate,
+            )
+            log.handlers.clear()
+            log.setLevel(logging.CRITICAL + 1)
+            log.propagate = False
+    try:
+        yield
+    finally:
+        with _pygnmi_suppress_lock:
+            _pygnmi_suppress_depth -= 1
+            if _pygnmi_suppress_depth == 0 and _pygnmi_suppress_saved is not None:
+                handlers, prev_level, prev_propagate = _pygnmi_suppress_saved
+                _pygnmi_suppress_saved = None
+                log.setLevel(prev_level)
+                log.propagate = prev_propagate
+                for h in handlers:
+                    log.addHandler(h)
 
 
 def _gnmi_path_missing(exc: BaseException) -> bool:
@@ -458,15 +505,17 @@ class RoutingMixin:
 
         path_spec: Dict[str, str] = PATH_SPECS[route_fam]
         rib_path = str(path_spec.get("path"))
-        try:
+        if route_fam in ("l3vpn-ipv4-unicast", "l3vpn-ipv6-unicast"):
+            with _suppress_pygnmi_client_logging():
+                try:
+                    resp = self.get(paths=[rib_path], datatype=path_spec["datatype"])
+                except BaseException as e:
+                    # Leaves / platforms without IP-VPN have no l3vpn-* RIB path; skip instead of failing.
+                    if _gnmi_path_missing(e):
+                        return {"bgp_rib": []}
+                    raise
+        else:
             resp = self.get(paths=[rib_path], datatype=path_spec["datatype"])
-        except BaseException as e:
-            # Leaves / platforms without IP-VPN have no l3vpn-* RIB path; skip instead of failing.
-            if route_fam in ("l3vpn-ipv4-unicast", "l3vpn-ipv6-unicast") and _gnmi_path_missing(
-                e
-            ):
-                return {"bgp_rib": []}
-            raise
         for ni in resp[0].get("network-instance", []):
             ni = augment_routes(ni, attribs[ni["name"]])
 
@@ -649,8 +698,8 @@ class RoutingMixin:
             "jmespath": '"network-instance"[].{NI:name, Neighbors: protocols.bgp.neighbor[].{"1_peer":"peer-address",\
                     "peer-as":"peer-as", state:"session-state","local-as":"_local-asn",flags:"_flags",\
                     "group":"peer-group", "export-policy":"export-policy", "import-policy":"import-policy",\
-                    "U4 R/A/T":"_ipv4", "U6 R/A/T":"_ipv6", "EV R/A/T":"_evpn", \
-                    "V4 R/A/T":"_l3vpn4", "V6 R/A/T":"_l3vpn6"}}',
+                    "U4\\nR/A/T":"_ipv4", "U6\\nR/A/T":"_ipv6", "EVPN\\nR/A/T":"_evpn",\
+                    "VPNv4\\nR/A/T":"_l3vpn4", "VPNv6\\nR/A/T":"_l3vpn6"}}',
             "datatype": "all",
             "key": "index",
         }

--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -637,7 +637,10 @@ class RoutingMixin:
                         else:
                             peer["_ipv6"] = "-"
                         if peer_data.get("l3vpn-ipv4-unicast"):
-                            if peer_data["l3vpn-ipv4-unicast"]["admin-state"] == "enable":
+                            if (
+                                peer_data["l3vpn-ipv4-unicast"]["admin-state"]
+                                == "enable"
+                            ):
                                 peer["_l3vpn4"] = (
                                     str(
                                         peer_data["l3vpn-ipv4-unicast"][
@@ -646,9 +649,7 @@ class RoutingMixin:
                                     )
                                     + "/"
                                     + str(
-                                        peer_data["l3vpn-ipv4-unicast"][
-                                            "active-routes"
-                                        ]
+                                        peer_data["l3vpn-ipv4-unicast"]["active-routes"]
                                     )
                                     + "/"
                                     + str(
@@ -665,7 +666,10 @@ class RoutingMixin:
                         else:
                             peer["_l3vpn4"] = "-"
                         if peer_data.get("l3vpn-ipv6-unicast"):
-                            if peer_data["l3vpn-ipv6-unicast"]["admin-state"] == "enable":
+                            if (
+                                peer_data["l3vpn-ipv6-unicast"]["admin-state"]
+                                == "enable"
+                            ):
                                 peer["_l3vpn6"] = (
                                     str(
                                         peer_data["l3vpn-ipv6-unicast"][
@@ -674,9 +678,7 @@ class RoutingMixin:
                                     )
                                     + "/"
                                     + str(
-                                        peer_data["l3vpn-ipv6-unicast"][
-                                            "active-routes"
-                                        ]
+                                        peer_data["l3vpn-ipv6-unicast"]["active-routes"]
                                     )
                                     + "/"
                                     + str(

--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -257,26 +257,28 @@ class RoutingMixin:
         }
         if route_fam in ("l3vpn-ipv4-unicast", "l3vpn-ipv6-unicast"):
             # Hyphenated YANG leaf names must be JMESPath quoted identifiers, not bare tokens.
-            _pfx_q = (
-                "ipv4-prefix"
+            # Some releases expose the VPN NLRI as ``prefix`` instead of ``ipv4-prefix`` /
+            # ``ipv6-prefix``; OR picks whichever is present.
+            _pfx_expr = (
+                '"ipv4-prefix" || prefix'
                 if route_fam == "l3vpn-ipv4-unicast"
-                else "ipv6-prefix"
+                else '"ipv6-prefix" || prefix'
             )
             ip_rib_jmespath_tail = {
                 1: (
                     f'.{{neighbor:neighbor, "0_st":"_r_state", "RD":"route-distinguisher", '
-                    f'"Pfx":"{_pfx_q}", "lpref":"local-pref", med:med, "next-hop":"next-hop",'
+                    f'"Pfx":{_pfx_expr}, "lpref":"local-pref", med:med, "next-hop":"next-hop",'
                     f'"as-path":"as-path".segment[0].member}}'
                 ),
                 2: (
                     f'.{{neighbor:neighbor, "0_st":"_r_state", "RD":"route-distinguisher", '
-                    f'"Pfx":"{_pfx_q}", "lpref":"local-pref", med:med, "next-hop":"next-hop",'
+                    f'"Pfx":{_pfx_expr}, "lpref":"local-pref", med:med, "next-hop":"next-hop",'
                     f'"as-path":"as-path".segment[0].member,'
                     '"communities":[communities.community, communities."large-community"][]|join(\', \',@)}}'
                 ),
                 3: (
                     f'.{{neighbor:neighbor, "0_st":"_r_state", "RD":"route-distinguisher", '
-                    f'"Pfx":"{_pfx_q}", "lpref":"local-pref", med:med, "next-hop":"next-hop",'
+                    f'"Pfx":{_pfx_expr}, "lpref":"local-pref", med:med, "next-hop":"next-hop",'
                     f'"as-path":"as-path".segment[0].member,'
                     '"communities":[communities.community, communities."large-community"][]|join(\',\',@)}}'
                 ),

--- a/nornir_srl/connections/routing.py
+++ b/nornir_srl/connections/routing.py
@@ -19,6 +19,13 @@ BGP_RIB_ROUTE_FAM_ALIASES: Dict[str, str] = {
 
 def _gnmi_path_missing(exc: BaseException) -> bool:
     """True when a gNMI Get failed because the path does not exist on the device."""
+    text = str(exc).lower()
+    # pygnmi embeds server text in gNMIException.args[0]; SR Linux uses this for unknown path elems.
+    if "path not valid" in text and (
+        "unknown element" in text or "l3vpn" in text or "unknown path" in text
+    ):
+        return True
+
     try:
         import grpc
 
@@ -35,18 +42,25 @@ def _gnmi_path_missing(exc: BaseException) -> bool:
         chain.append(exc.__cause__)
     if exc.__context__ is not None and exc.__context__ is not exc.__cause__:
         chain.append(exc.__context__)
+    # pygnmi wraps grpc errors in gNMIException(..., orig_exc=...) without raise-from chaining.
+    orig = getattr(exc, "orig_exc", None)
+    if isinstance(orig, BaseException):
+        chain.append(orig)
+
+    def _code_match(obj: Any) -> bool:
+        code_fn = getattr(obj, "code", None)
+        if not callable(code_fn):
+            return False
+        try:
+            return bool(code_fn() in missing)
+        except Exception:
+            return False
 
     for cur in chain:
-        if cur is None:
-            continue
-        code_fn = getattr(cur, "code", None)
-        if not callable(code_fn):
-            continue
-        try:
-            if code_fn() in missing:
-                return True
-        except Exception:
-            continue
+        if cur is not None and _code_match(cur):
+            return True
+    if orig is not None and not isinstance(orig, BaseException) and _code_match(orig):
+        return True
     return False
 
 

--- a/nornir_srl/mcp_server.py
+++ b/nornir_srl/mcp_server.py
@@ -488,8 +488,9 @@ def bgp_peers(
     """Get BGP peer status and route statistics for all network instances.
 
     Returns peer address, peer AS, session state, local AS, flags (D=dynamic, B=BFD, F=fast-failover),
-    and Rx/Active/Tx route counts per AFI/SAFI: IPv4 unicast (U4), IPv6 unicast (U6), EVPN (EV),
-    L3VPN IPv4 (V4), L3VPN IPv6 (V6).
+    and Rx/Active/Tx route counts per AFI/SAFI: IPv4 unicast (U4), IPv6 unicast (U6), EVPN,
+    L3VPN IPv4 (VPNv4), L3VPN IPv6 (VPNv6). Table column headers show the AFI on the first line
+    and R/A/T on the second; JSON keys use a space instead of the newline.
 
     Args:
         inv_filter: Inventory filter as comma-separated key=value pairs (e.g. 'role=spine'). Supports wildcards.

--- a/nornir_srl/mcp_server.py
+++ b/nornir_srl/mcp_server.py
@@ -488,7 +488,8 @@ def bgp_peers(
     """Get BGP peer status and route statistics for all network instances.
 
     Returns peer address, peer AS, session state, local AS, flags (D=dynamic, B=BFD, F=fast-failover),
-    and route counts (Rx/Active/Tx) for IPv4, IPv6, and EVPN address families.
+    and Rx/Active/Tx route counts per AFI/SAFI: IPv4 unicast (U4), IPv6 unicast (U6), EVPN (EV),
+    L3VPN IPv4 (V4), L3VPN IPv6 (V6).
 
     Args:
         inv_filter: Inventory filter as comma-separated key=value pairs (e.g. 'role=spine'). Supports wildcards.
@@ -508,7 +509,15 @@ def bgp_peers(
 
 @mcp.tool()
 def bgp_rib(
-    route_fam: Literal["evpn", "ipv4", "ipv6"],
+    route_fam: Literal[
+        "evpn",
+        "ipv4",
+        "ipv6",
+        "l3vpn-v4",
+        "l3vpn-v6",
+        "l3vpn-ipv4-unicast",
+        "l3vpn-ipv6-unicast",
+    ],
     route_type: Optional[Literal["1", "2", "3", "4", "5"]] = None,
     inv_filter: Optional[str] = None,
     field_filter: Optional[str] = None,
@@ -522,7 +531,8 @@ def bgp_rib(
     EVPN/IP-VPN loop-prevention and route-leaking issues.
 
     Args:
-        route_fam: Route family - one of 'evpn', 'ipv4', 'ipv6'.
+        route_fam: BGP RIB address family: evpn, ipv4, ipv6, or L3VPN IPv4/IPv6 unicast
+            (``l3vpn-v4`` / ``l3vpn-v6`` short names, or ``l3vpn-ipv4-unicast`` / ``l3vpn-ipv6-unicast``).
         route_type: Route type for EVPN (1-5). Only applicable when route_fam='evpn'.
             1=Ethernet Auto-Discovery, 2=MAC/IP, 3=Inclusive Multicast, 4=ES, 5=IP Prefix.
         inv_filter: Inventory filter as comma-separated key=value pairs. Supports wildcards.

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -23,6 +23,8 @@ def test_clean_structured_key_strips_order_prefix():
 def test_clean_structured_key_collapses_newlines():
     assert clean_structured_key("AF: EVPN\nRx/Act/Tx") == "AF: EVPN Rx/Act/Tx"
     assert clean_structured_key("U4 R/A/T") == "U4 R/A/T"
+    assert clean_structured_key("U4\nR/A/T") == "U4 R/A/T"
+    assert clean_structured_key("EVPN\nR/A/T") == "EVPN R/A/T"
 
 
 def test_clean_structured_key_leaves_plain_keys():

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -318,6 +318,79 @@ def test_get_bgp_rib_l3vpn_returns_empty_when_rib_path_absent():
     assert dev.get_bgp_rib(route_fam="l3vpn-v4") == {"bgp_rib": []}
 
 
+def test_get_bgp_rib_l3vpn_empty_on_pygnmi_path_invalid_message():
+    """pygnmi surfaces SR Linux path errors as a string (no grpc __cause__ chain)."""
+
+    class _LeafNoL3vpnPygnmi(_FakeRouting):
+        def get(
+            self,
+            paths: List[str],
+            datatype: Optional[str] = "config",
+            strip_mod: Optional[bool] = True,
+        ) -> List[Dict[str, Any]]:
+            p = paths[0]
+            if "l3vpn-ipv4-unicast" in p and "local-rib" in p:
+                raise RuntimeError(
+                    "GRPC ERROR Host: leaf2:57400, Error: Path not valid - unknown element "
+                    "'l3vpn-ipv4-unicast'. Options are [ipv4-unicast, ipv6-unicast, evpn, "
+                    "ipv4-flowspec-v1, ipv6-flowspec-v1, route-target, afi-safi-name]"
+                )
+            return super().get(paths, datatype, strip_mod)
+
+    attr_only = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {"attr-sets": {"attr-set": []}},
+                }
+            ]
+        }
+    ]
+    dev = _LeafNoL3vpnPygnmi({"attr-sets/attr-set": attr_only})
+    assert dev.get_bgp_rib(route_fam="l3vpn-v4") == {"bgp_rib": []}
+
+
+def test_get_bgp_rib_l3vpn_empty_when_orig_exc_has_grpc_code():
+    """pygnmi ``gNMIException`` stores RpcError in ``orig_exc``, not ``__cause__``."""
+
+    import grpc
+
+    class _InactiveLike:
+        def code(self) -> grpc.StatusCode:
+            return grpc.StatusCode.INVALID_ARGUMENT
+
+    class _GnmiExcWrapper(Exception):
+        def __init__(self) -> None:
+            super().__init__("GRPC ERROR Host: leaf:57400, Error: Path not valid")
+            self.orig_exc = _InactiveLike()
+
+    class _LeafOrig(_FakeRouting):
+        def get(
+            self,
+            paths: List[str],
+            datatype: Optional[str] = "config",
+            strip_mod: Optional[bool] = True,
+        ) -> List[Dict[str, Any]]:
+            p = paths[0]
+            if "l3vpn-ipv4-unicast" in p and "local-rib" in p:
+                raise _GnmiExcWrapper()
+            return super().get(paths, datatype, strip_mod)
+
+    attr_only = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {"attr-sets": {"attr-set": []}},
+                }
+            ]
+        }
+    ]
+    dev = _LeafOrig({"attr-sets/attr-set": attr_only})
+    assert dev.get_bgp_rib(route_fam="l3vpn-v4") == {"bgp_rib": []}
+
+
 # --------------------------------------------------------------------------- #
 # get_tunnel_table next-hop resolution
 # --------------------------------------------------------------------------- #

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -22,6 +22,7 @@ def test_clean_structured_key_strips_order_prefix():
 
 def test_clean_structured_key_collapses_newlines():
     assert clean_structured_key("AF: EVPN\nRx/Act/Tx") == "AF: EVPN Rx/Act/Tx"
+    assert clean_structured_key("U4 R/A/T") == "U4 R/A/T"
 
 
 def test_clean_structured_key_leaves_plain_keys():
@@ -212,6 +213,74 @@ def test_get_bgp_rib_evpn_lean_has_no_extra_attrs():
     assert "soo" not in route
     assert "dpath" not in route
     assert "communities" not in route
+
+
+def test_get_bgp_rib_l3vpn_ipv4_alias_and_columns():
+    """L3VPN IPv4 RIB uses RD + Pfx; ``l3vpn-v4`` is an accepted alias."""
+    attr_sets = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {
+                        "attr-sets": {
+                            "attr-set": [
+                                {
+                                    "index": 1,
+                                    "as-path": {"segment": [{"member": [65002, "i"]}]},
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+    ]
+    routes = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {
+                        "afi-safi": [
+                            {
+                                "afi-safi-name": "l3vpn-ipv4-unicast",
+                                "l3vpn-ipv4-unicast": {
+                                    "local-rib": {
+                                        "route": [
+                                            {
+                                                "attr-id": 1,
+                                                "used-route": True,
+                                                "valid-route": True,
+                                                "best-route": True,
+                                                "neighbor": "10.0.0.6",
+                                                "route-distinguisher": "65000:1",
+                                                "ipv4-prefix": "172.16.1.0/24",
+                                                "next-hop": "10.0.0.6",
+                                                "local-pref": 100,
+                                                "med": 0,
+                                                "communities": {
+                                                    "community": [],
+                                                    "large-community": [],
+                                                },
+                                            }
+                                        ]
+                                    }
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    ]
+    dev = _FakeRouting({"attr-sets/attr-set": attr_sets, "local-rib/route": routes})
+    out = dev.get_bgp_rib(route_fam="l3vpn-v4", detail=False)
+    route = out["bgp_rib"][0]["Rib"][0]
+    assert route["RD"] == "65000:1"
+    assert route["Pfx"] == "172.16.1.0/24"
+    assert route["neighbor"] == "10.0.0.6"
+    assert route["0_st"] == "u*>"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -283,6 +283,41 @@ def test_get_bgp_rib_l3vpn_ipv4_alias_and_columns():
     assert route["0_st"] == "u*>"
 
 
+def test_get_bgp_rib_l3vpn_returns_empty_when_rib_path_absent():
+    """Nodes without an L3VPN RIB path (e.g. EVPN-only leaves) return an empty RIB."""
+
+    import grpc
+
+    class _RpcNotFound(Exception):
+        def code(self) -> grpc.StatusCode:
+            return grpc.StatusCode.NOT_FOUND
+
+    class _LeafNoL3vpn(_FakeRouting):
+        def get(
+            self,
+            paths: List[str],
+            datatype: Optional[str] = "config",
+            strip_mod: Optional[bool] = True,
+        ) -> List[Dict[str, Any]]:
+            p = paths[0]
+            if "l3vpn-ipv4-unicast" in p and "local-rib" in p:
+                raise _RpcNotFound()
+            return super().get(paths, datatype, strip_mod)
+
+    attr_only = [
+        {
+            "network-instance": [
+                {
+                    "name": "default",
+                    "bgp-rib": {"attr-sets": {"attr-set": []}},
+                }
+            ]
+        }
+    ]
+    dev = _LeafNoL3vpn({"attr-sets/attr-set": attr_only})
+    assert dev.get_bgp_rib(route_fam="l3vpn-v4") == {"bgp_rib": []}
+
+
 # --------------------------------------------------------------------------- #
 # get_tunnel_table next-hop resolution
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- Extend `fcli bgp-rib` / `get_bgp_rib` for **L3VPN IPv4 and IPv6 unicast** (`l3vpn-ipv4-unicast` / `l3vpn-ipv6-unicast`), with short CLI aliases **`l3vpn-v4`** and **`l3vpn-v6`**. Table columns use **RD** and **Pfx** (JMESPath uses quoted identifiers for hyphenated YANG leaves). `BGP_RIB_ROUTE_FAM_ALIASES` is exported from `routing.py` for reuse; the table title shows the canonical family name.
- Update **`bgp-peers`** / `get_sum_bgp` to report **L3VPN IPv4 and IPv6** received/active/sent counts (same semantics as existing unicast families). **Condensed AFI headers** (`U4` / `U6` / `EV` / `V4` / `V6` + `R/A/T`) to limit table width; README documents the legend.
- MCP `bgp_rib` tool `route_fam` literal extended; `bgp_peers` docstring updated.

## Test plan

- [x] `uv run pytest` (all tests pass, including new `test_get_bgp_rib_l3vpn_ipv4_alias_and_columns`).
- [ ] On a lab with L3VPN (e.g. DCGW IP-VPN): `fcli bgp-rib -r l3vpn-v4` / `-r l3vpn-v6` and `fcli bgp-peers` to confirm live gNMI paths and counters match the CLI.

Made with [Cursor](https://cursor.com)